### PR TITLE
Remove obsolete nntp-authinfo-file

### DIFF
--- a/gmail-gnus-gpg.el
+++ b/gmail-gnus-gpg.el
@@ -28,8 +28,6 @@
       smtpmail-smtp-service 587
       ;; Tell message mode to use SMTP.
       message-send-mail-function 'smtpmail-send-it
-      ;; This is where we store the password.
-      nntp-authinfo-file "~/.authinfo.gpg"
       ;; Gmail system labels have the prefix [Gmail], which matches
       ;; the default value of gnus-ignored-newsgroups. That's why we
       ;; redefine it.


### PR DESCRIPTION
From the GNU Emacs change log:
```
* nntp.el (nntp-authinfo-file): Mark as obsolete -- use auth-source instead.
```
This is deprecated as of 24.1, `~/.authinfo` (or `~/.authinfo.gpg`) is used by default, see variable `auth-sources`.