### PR TITLE
Replace mml2015-encrypt-to-self

### DIFF
--- a/gmail-gnus-gpg.el
+++ b/gmail-gnus-gpg.el
@@ -39,7 +39,7 @@
       ;; We don't want local, unencrypted copies of emails we write.
       gnus-message-archive-group nil
       ;; We want to be able to read the emails we wrote.
-      mml2015-encrypt-to-self t)
+      mml-secure-openpgp-encrypt-to-self t)
 
 ;; Attempt to encrypt all the mails we'll be sending.
 (add-hook 'message-setup-hook 'mml-secure-message-encrypt)


### PR DESCRIPTION
The `mml2015-encrypt-to-self` variable is an alias for `mml-secure-openpgp-encrypt-to-self`.
This variable is obsolete since 25.1; use `mml-secure-openpgp-encrypt-to-self` instead.